### PR TITLE
Disable breaking word only when the disable_word_break option is enabled

### DIFF
--- a/lib/prawn/disable_word_break.rb
+++ b/lib/prawn/disable_word_break.rb
@@ -1,9 +1,28 @@
 # frozen_string_literal: true
 
 require 'prawn'
+require 'forwardable'
 
 require_relative 'disable_word_break/version'
 require_relative 'disable_word_break/wrap'
 
-Prawn::Text::Box.extensions << Prawn::DisableWordBreak::Wrap
-Prawn::Text::Formatted::Box.extensions << Prawn::DisableWordBreak::Wrap
+module Prawn
+  module DisableWordBreak
+    extend Forwardable
+
+    Config = Struct.new(
+      # Sets the default value for the disable_word_break option. Default is false.
+      :default,
+
+      keyword_init: true
+    )
+
+    def self.config
+      @config ||= Config.new(default: false)
+    end
+  end
+end
+
+Prawn::DisableWordBreak::Wrap.tap do |mod|
+  Prawn::Text::Formatted::Wrap.prepend(mod) unless Prawn::Text::Formatted::Wrap.include?(mod)
+end

--- a/lib/prawn/disable_word_break/line_break_anywhere.rb
+++ b/lib/prawn/disable_word_break/line_break_anywhere.rb
@@ -2,7 +2,7 @@
 
 module Prawn
   module DisableWordBreak
-    class LineWrap < Text::Formatted::LineWrap
+    class LineBreakAnywhere < Text::Formatted::LineWrap
       private
 
       # Override

--- a/lib/prawn/disable_word_break/wrap.rb
+++ b/lib/prawn/disable_word_break/wrap.rb
@@ -1,14 +1,20 @@
 # frozen_string_literal: true
 
-require_relative 'line_wrap'
+require_relative 'line_break_anywhere'
 
 module Prawn
   module DisableWordBreak
     module Wrap
       # override
-      def wrap(*)
-        @line_wrap = DisableWordBreak::LineWrap.new
+      def initialize(_, options)
         super
+
+        @line_wrap = LineBreakAnywhere.new if DisableWordBreak.config.default || options[:disable_word_break]
+      end
+
+      # override
+      def valid_options
+        super + %i(disable_word_break)
       end
     end
   end

--- a/test/features/text_line_wrapping_test.rb
+++ b/test/features/text_line_wrapping_test.rb
@@ -1,18 +1,21 @@
 # frozen_string_literal: true
 
 require 'features/test_helper'
+require 'prawn/disable_word_break'
 
 class TextLineWrappingTest < Test::Unit::TestCase
   include TestHelper
 
   test 'text line-wrapping' do
     pdf = Prawn::Document.new do |doc|
-      doc.instance_eval(&renderer_on(word_break_disabled: false))
-
-      require 'prawn/disable_word_break'
+      doc.instance_eval(&renderer_on("Word breaks is enabled", disable_word_break_option: false))
 
       doc.start_new_page
-      doc.instance_eval(&renderer_on(word_break_disabled: true))
+      doc.instance_eval(&renderer_on("Word breaks is disabled by disable_word_break: true", disable_word_break_option: true))
+
+      ::Prawn::DisableWordBreak.config.default = true
+      doc.start_new_page
+      doc.instance_eval(&renderer_on("Word breaks is disabled by Prawn::DisablwWordBreak.config.deafult = true", disable_word_break_option: false))
     end
 
     assert_expected_pdf 'text_line_wrapping', pdf.render
@@ -20,14 +23,14 @@ class TextLineWrappingTest < Test::Unit::TestCase
 
   private
 
-  def renderer_on(word_break_disabled:)
+  def renderer_on(title, disable_word_break_option: false)
     font_dir = root_dir.join('../fonts')
     box_size = { width: 150, height: 50 }
 
     proc do
       font font_dir.join('DejaVuSans.ttf')
 
-      font_size(20) { text "Word-breaking is #{word_break_disabled ? 'disabled' : 'enabled' }" }
+      font_size(14) { text title }
       move_down 10
 
       text 'Spaces'
@@ -35,16 +38,16 @@ class TextLineWrappingTest < Test::Unit::TestCase
 
       text_for_spaces = 'aaaaaa bbbbbb cccccccccccccccc'
 
-      text_box "#text_box:\n#{text_for_spaces}", at: [0, cursor], **box_size
+      text_box "#text_box:\n#{text_for_spaces}", at: [0, cursor], disable_word_break: disable_word_break_option, **box_size
 
       stroke { rectangle [0, cursor], *box_size.values }
 
-      formatted_text_box [{ text: "#formatted_text_box:\n#{text_for_spaces}" }], at: [180, cursor], **box_size
+      formatted_text_box [{ text: "#formatted_text_box:\n#{text_for_spaces}" }], at: [180, cursor], disable_word_break: disable_word_break_option, **box_size
 
       stroke { rectangle [180, cursor], *box_size.values }
 
       bounding_box [360, cursor], **box_size do
-        text "#bounding_box:\n#{text_for_spaces}"
+        text "#bounding_box:\n#{text_for_spaces}", disable_word_break: disable_word_break_option
         stroke_bounds
       end
 
@@ -55,16 +58,17 @@ class TextLineWrappingTest < Test::Unit::TestCase
 
       text_for_tabs = "aaaaaa\tbbbbbb\tcccccccccccccccc"
 
-      text_box "#text_box:\n#{text_for_tabs}", at: [0, cursor], **box_size
+      text_box "#text_box:\n#{text_for_tabs}", at: [0, cursor], disable_word_break: disable_word_break_option, **box_size
 
       stroke { rectangle [0, cursor], *box_size.values }
 
-      formatted_text_box [{ text: "#formatted_text_box:\n#{text_for_tabs}" }], at: [180, cursor], **box_size
+      formatted_text_box [{ text: "#formatted_text_box:\n#{text_for_tabs}" }],
+        at: [180, cursor], disable_word_break: disable_word_break_option, **box_size
 
       stroke { rectangle [180, cursor], *box_size.values }
 
       bounding_box [360, cursor], **box_size do
-        text "#bounding_box:\n#{text_for_tabs}"
+        text "#bounding_box:\n#{text_for_tabs}", disable_word_break: disable_word_break_option
         stroke_bounds
       end
 
@@ -75,16 +79,17 @@ class TextLineWrappingTest < Test::Unit::TestCase
 
       text_for_hard_hyphens = 'aaaaaa-bbbbbb-cccccccccccccccc'
 
-      text_box "#text_box:\n#{text_for_hard_hyphens}", at: [0, cursor], **box_size
+      text_box "#text_box:\n#{text_for_hard_hyphens}", at: [0, cursor], disable_word_break: disable_word_break_option, **box_size
 
       stroke { rectangle [0, cursor], *box_size.values }
 
-      formatted_text_box [{ text: "#formatted_text_box:\n#{text_for_hard_hyphens}" }], at: [180, cursor], **box_size
+      formatted_text_box [{ text: "#formatted_text_box:\n#{text_for_hard_hyphens}" }],
+        at: [180, cursor], disable_word_break: disable_word_break_option, **box_size
 
       stroke { rectangle [180, cursor], *box_size.values }
 
       bounding_box [360, cursor], **box_size do
-        text "#bounding_box:\n#{text_for_hard_hyphens}"
+        text "#bounding_box:\n#{text_for_hard_hyphens}", disable_word_break: disable_word_break_option
         stroke_bounds
       end
 
@@ -96,16 +101,17 @@ class TextLineWrappingTest < Test::Unit::TestCase
       shy = Prawn::Text::SHY
       text_for_soft_hyphens = "aaaaaa#{shy}bbbbbb#{shy}cccccccccccccccc"
 
-      text_box "#text_box:\n#{text_for_soft_hyphens}", at: [0, cursor], **box_size
+      text_box "#text_box:\n#{text_for_soft_hyphens}", at: [0, cursor], disable_word_break: disable_word_break_option, **box_size
 
       stroke { rectangle [0, cursor], *box_size.values }
 
-      formatted_text_box [{ text: "#formatted_text_box:\n#{text_for_soft_hyphens}" }], at: [180, cursor], **box_size
+      formatted_text_box [{ text: "#formatted_text_box:\n#{text_for_soft_hyphens}" }],
+        at: [180, cursor], disable_word_break: disable_word_break_option, **box_size
 
       stroke { rectangle [180, cursor], *box_size.values }
 
       bounding_box [360, cursor], **box_size do
-        text "#bounding_box:\n#{text_for_soft_hyphens}"
+        text "#bounding_box:\n#{text_for_soft_hyphens}", disable_word_break: disable_word_break_option
         stroke_bounds
       end
 
@@ -118,16 +124,17 @@ class TextLineWrappingTest < Test::Unit::TestCase
       zwsp = Prawn::Text::ZWSP
       text_for_zwsp = "aaaaaa#{zwsp}bbbbbb#{zwsp}cccccccccccccccc"
 
-      text_box "#text_box:\n#{text_for_zwsp}", at: [0, cursor], **box_size
+      text_box "#text_box:\n#{text_for_zwsp}", at: [0, cursor], disable_word_break: disable_word_break_option, **box_size
 
       stroke { rectangle [0, cursor], *box_size.values }
 
-      formatted_text_box [{ text: "#formatted_text_box:\n#{text_for_zwsp}" }], at: [180, cursor], **box_size
+      formatted_text_box [{ text: "#formatted_text_box:\n#{text_for_zwsp}" }],
+        at: [180, cursor], disable_word_break: disable_word_break_option, **box_size
 
       stroke { rectangle [180, cursor], *box_size.values }
 
       bounding_box [360, cursor], **box_size do
-        text "#bounding_box:\n#{text_for_zwsp}"
+        text "#bounding_box:\n#{text_for_zwsp}", disable_word_break: disable_word_break_option
         stroke_bounds
       end
 
@@ -137,16 +144,17 @@ class TextLineWrappingTest < Test::Unit::TestCase
       move_down 10
 
       font font_dir.join('ipag.ttf') do
-        text_box "#text_box:\nああああああああ-いいいいいいい", at: [0, cursor], **box_size
+        text_box "#text_box:\nああああああああ-いいいいいいい", at: [0, cursor], disable_word_break: disable_word_break_option, **box_size
 
         stroke { rectangle [0, cursor], *box_size.values }
 
-        formatted_text_box [{ text: "#formatted_text_box:\nああああああああ いいいいいいい" }], at: [180, cursor], **box_size
+        formatted_text_box [{ text: "#formatted_text_box:\nああああああああ いいいいいいい" }],
+          at: [180, cursor], disable_word_break: disable_word_break_option, **box_size
 
         stroke { rectangle [180, cursor], *box_size.values }
 
         bounding_box [360, cursor], **box_size do
-          text "#bounding_box:\nああああああああ#{zwsp}いいいいいいい"
+          text "#bounding_box:\nああああああああ#{zwsp}いいいいいいい", disable_word_break: disable_word_break_option
           stroke_bounds
         end
       end


### PR DESCRIPTION
Change to the following specification.

* Disable text line wrapping only when the disable_word_break option is enabled
